### PR TITLE
Fixed removing event listeners

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,14 @@
 const Cryptr = require('cryptr');
-const { emit, on } = require('./symbol');
+const { emit, on, off, send } = require('./symbol');
 const reservedEvents = require('./reserved-events');
 
 module.exports = (secret) => (socket, next) => {
+  const handlers = new Map();
   const cryptr = new Cryptr(secret);
 
   const encrypt = args => {
     const encrypted = [];
-    let ack;
+    let ack
     for (let i = 0; i < args.length; i++) {
       const arg = args[i];
       if (i === args.length - 1 && typeof arg === 'function') {
@@ -25,7 +26,7 @@ module.exports = (secret) => (socket, next) => {
 
   const decrypt = encrypted => {
     try {
-      return encrypted.map(a => JSON.parse(cryptr.decrypt(a)));
+      return encrypted.map(a => JSON.parse(cryptr.decrypt(a)))
     } catch (e) {
       const error = new Error(`Couldn't decrypt. Wrong secret used on client or invalid data sent. (${e.message})`);
       error.code = 'ERR_DECRYPTION_ERROR';
@@ -35,6 +36,7 @@ module.exports = (secret) => (socket, next) => {
 
   socket[emit] = socket.emit;
   socket[on] = socket.on;
+  socket[off] = socket.off;
 
   socket.emit = (event, ...args) => {
     if (reservedEvents.includes(event)) return socket[emit](event, ...args);
@@ -45,7 +47,7 @@ module.exports = (secret) => (socket, next) => {
   socket.on = (event, handler) => {
     if (reservedEvents.includes(event)) return socket[on](event, handler);
 
-    return socket[on](event, function(...args) {
+    const newHandler = function(...args) {
       if (args[0] && args[0].encrypted) {
         try {
           args = decrypt(args[0].encrypted);
@@ -55,8 +57,21 @@ module.exports = (secret) => (socket, next) => {
         }
       }
       return handler.call(this, ...args);
-    });
+    };
+    
+    handlers.set(handler, newHandler);
+    return socket[on](event, newHandler);
   };
+
+  socket.off = (event, handler) => {
+    if (reservedEvents.includes(event)) return socket[off](event, handler);
+
+    if (handlers.has(handler)) {
+      return socket[off](event, handlers.get(handler));
+    }
+    
+    return socket[off](event, handler);
+  }
 
   if (next) next();
   return socket;


### PR DESCRIPTION
Testing code:
```js
console.log("REGISTERED LISTENERS", socket.listeners("eventname"));
socket.on("eventname", this.eventListener);
console.log("REGISTERED LISTENERS", socket.listeners("eventname"));
socket.off("eventname", this.eventListener);
console.log("REGISTERED LISTENERS", socket.listeners("eventname"));
```
Before:
```
REGISTERED LISTENERS []
REGISTERED LISTENERS [ƒ]
REGISTERED LISTENERS [ƒ]
```
After:
```
REGISTERED LISTENERS []
REGISTERED LISTENERS [ƒ]
REGISTERED LISTENERS []
```

Fixes `socket.off("eventname", listener);`.
Now it properly removes event listener.